### PR TITLE
Fixes

### DIFF
--- a/Mockista/ClassGenerator/ClassGenerator.php
+++ b/Mockista/ClassGenerator/ClassGenerator.php
@@ -33,6 +33,13 @@ class ClassGenerator extends BaseClassGenerator
 			if ("__call" == $name || "__construct" == $name || $method['final']) {
 				continue;
 			}
+			if ("__destruct" == $name) {
+				$out .= '
+	function __destruct()
+	{
+	}
+'; 			continue;
+			}
 			$out .= $this->generateMethod($name, $method);
 		}
 		$out .= "}\n";

--- a/tests/ClassGenerator/ClassGeneratorTest.php
+++ b/tests/ClassGenerator/ClassGeneratorTest.php
@@ -91,6 +91,10 @@ class A_B_ClassGeneratorTest_Empty_Generated implements ClassGeneratorTest_Empty
 		$l = call_user_func_array(array($this->mockista, \'abc\'), func_get_args());
 		return $l;
 	}
+
+	function __destruct()
+	{
+	}
 }
 ';
 		$this->object->setMethodFinder(new MethodFinder());

--- a/tests/fixtures/classGenerator.php
+++ b/tests/fixtures/classGenerator.php
@@ -23,7 +23,10 @@ class ClassGeneratorTest_Method
 
 	final function finalMethod()
 	{
+	}
 
+	function __destruct()
+	{
 	}
 }
 


### PR DESCRIPTION
Dvě změny:

1) Metody generovaných tříd nejprve přiřadí výsledek do proměnné. To odstraňuje problém, kdy se vrací reference - notice "Only variable references should be returned by reference"

2) Generování metody __destruct() - pokud ve třídě metoda __destruct je, dostáváme "unexpected call to __destruct()"
