### PR TITLE
Add phpunit into dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
 		}
 	],
 	"license": "BSD-3-Clause",
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
 	"autoload": {
 		"psr-0": {
 			"Mockista": ""


### PR DESCRIPTION
For better testing without available global phpunit.
- add composer.lock into git ignories
