### PR TITLE
improved unique class name generation for mocked classes (closes #12)

### DIFF
--- a/Mockista/MockBuilder.php
+++ b/Mockista/MockBuilder.php
@@ -35,7 +35,7 @@ class MockBuilder
 			$classGenerator = new ClassGenerator();
 			$classGenerator->setMethodFinder(new MethodFinder());
 
-			$newName = str_replace("\\", "_", $class) . '_' . uniqid();
+			$newName = str_replace("\\", "_", $class) . '_' . mt_rand();
 			$code = $classGenerator->generate($class, $newName);
 
 			eval($code);


### PR DESCRIPTION
MockBuilder::createMock uses mt_rand function instead of uniqid. Uniqid could have problems with its result uniqueness.
