### PR TITLE
Registry - ability create and retrieve named mocks.

### DIFF
--- a/Mockista/Method.php
+++ b/Mockista/Method.php
@@ -181,7 +181,7 @@ class Method implements MethodInterface
 		$message = "";
 		$code = 0;
 
-		$mockName = $this->owningMock->mockName;
+		$mockName = $this->owningMock->getMockName();
 		if (empty($mockName)) {
 			$mockName = 'unnamed';
 		}

--- a/Mockista/Mock.php
+++ b/Mockista/Mock.php
@@ -9,7 +9,7 @@ class Mock implements MockInterface
 
 	private $argsMatcher;
 
-	public $mockName = NULL;
+	private $mockName = NULL;
 
 	public function __construct()
 	{
@@ -23,6 +23,14 @@ class Mock implements MockInterface
 				$argCombinationMethod->assertExpectations();
 			}
 		}
+	}
+
+	public function getMockName() {
+		return $this->mockName;
+	}
+
+	public function setMockName($name) {
+		$this->mockName = $name;
 	}
 
 	private function checkMethodsNamespace($name)

--- a/Mockista/MockBuilder.php
+++ b/Mockista/MockBuilder.php
@@ -47,7 +47,7 @@ class MockBuilder
 			eval($code);
 			$mock = new $newName();
 			$mock->mockista = new Mock();
-			$mock->mockista->mockName = $class;
+			$mock->mockista->setMockName($class);
 		} else {
 			$mock = new Mock();
 		}

--- a/Mockista/Registry.php
+++ b/Mockista/Registry.php
@@ -52,14 +52,9 @@ class Registry
 		$builder = new MockBuilder($class, $methods);
 		$mock = $builder->getMock();
 		if (isset($this->mocks[$name])) {
-			throw new MockException("Mock with name {$mock->mockName} is already registered.");
+			throw new MockException("Mock with name {$name} is already registered.");
 		}
-		if ($mock instanceof Mock) {
-			$mock->mockName = $name;
-		} else {
-			$mock->mockista->mockName = $name;
-		}
-
+		$mock->setMockName($name);
 		$this->mocks[$name] = $mock;
 		$this->mockId++;
 		return $builder;

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -71,7 +71,7 @@ class MockBuilderTest extends \PHPUnit_Framework_TestCase
 	function testMockedClassHasName() {
 		$builder = new MockBuilder('Mockista\A');
 		$mock = $builder->getMock();
-		$this->assertEquals('Mockista\A', $mock->mockista->mockName);
+		$this->assertEquals('Mockista\A', $mock->mockista->getMockName());
 	}
 
 	function testMockedMethodHasOwningMockAndName() {

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -25,12 +25,12 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	function test_mocks_are_named_properly() {
-		$this->assertEquals('#1', $this->object->create()->mockName);
-		$this->assertEquals('service', $this->object->createNamed('service')->mockName);
-		$this->assertEquals('stdClass#3', $this->object->createBuilder('stdClass')->getMock()->mockName);
-		$this->assertEquals('#4', $this->object->create()->mockName);
-		$this->assertEquals('Mockista\A#5', $this->object->create('Mockista\A')->mockName);
-		$this->assertEquals('abc', $this->object->createNamedBuilder('abc', 'Mockista\A')->getMock()->mockName);
+		$this->assertEquals('#1', $this->object->create()->getMockName());
+		$this->assertEquals('service', $this->object->createNamed('service')->getMockName());
+		$this->assertEquals('stdClass#3', $this->object->createBuilder('stdClass')->getMock()->getMockName());
+		$this->assertEquals('#4', $this->object->create()->getMockName());
+		$this->assertEquals('Mockista\A#5', $this->object->create('Mockista\A')->getMockName());
+		$this->assertEquals('abc', $this->object->createNamedBuilder('abc', 'Mockista\A')->getMock()->getMockName());
 	}
 
 	/**
@@ -53,7 +53,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 		$this->object->createNamed('first');
 		$mock = $this->object->getMock('first');
 		$this->assertInstanceOf('Mockista\\Mock', $mock);
-		$this->assertEquals('first', $mock->mockName);
+		$this->assertEquals('first', $mock->getMockName());
 	}
 
 	/**


### PR DESCRIPTION
You can now create named mocks/builders to later retrieval in tests methods to fine-tune them.
Idea taken from: http://www.zdrojak.cz/clanky/knihovna-testit-phpunit/

For creating named mocks, two methods ara available: createNamed('name', ...) and createNamedBuilder('name', ....).

For retrieving named mocks in tests methods, you have two new methods getMock('name') and getBuilder('name')
