### PR TITLE
Update Mock.php

### DIFF
--- a/Mockista/Mock.php
+++ b/Mockista/Mock.php
@@ -67,7 +67,7 @@ class Mock implements MockInterface
 		}
 
 		if (!$best) {
-			$argsStr = var_export($args, TRUE);
+			$argsStr = @var_export($args, TRUE); // intentionally used shut-up operator (@) to prevent "var_export does not handle circular references" warning
 			$objectName = $this->name ? $this->name : 'unnammed';
 			throw new MockException("Unexpected call in mock $objectName::$name(), args: $argsStr", MockException::CODE_INVALID_ARGS);
 		}


### PR DESCRIPTION
Ahoj, 

tato drobna uprava se hodi, aby uzivatel dostal spravnou chybovou hlasku (tedy "Unexpected call in mock ...") misto neuzitecne hlasky "PHPUnit_Framework_Error_Warning #2 - var_export does not handle circular references".

Hezky den!
