### PR TITLE
Add Method:withAny() - this allows $builder->abc()->withAny()

### DIFF
--- a/Mockista/Method.php
+++ b/Mockista/Method.php
@@ -54,6 +54,12 @@ class Method implements MethodInterface
 		return $this;
 	}
 
+	public function withAny()
+	{
+		$this->args = NULL;
+		return $this;
+	}
+
 	public function matchArgs($arguments)
 	{
 		return $this->argsMatcher->serializeArgs($arguments) === $this->args;

--- a/tests/MockistaTest.php
+++ b/tests/MockistaTest.php
@@ -35,6 +35,15 @@ class MockistaTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue($method instanceof MethodInterface);
 	}
 
+	public function testWithAny()
+	{
+		$method = $this->object->expects('abc')->with(1, 2)->withAny();
+		$this->object->abc('any');
+		$this->object->abc(4, 5);
+		$this->object->abc();
+		$this->object->assertExpectations();
+	}
+
 	public function testMethodReturn()
 	{
 		$this->object->expects('abc')->andReturn(11);


### PR DESCRIPTION
This will accepts any calls (with any parameters) to $mock->abc(). This ability is already there, but it is not possible to access using builder, you have to do something like

```
  $builder->getMock()->expects('abc')->...
```

This way it is more readeble

```
  $builder->abc()->withAny()->...
```
