### PR TITLE
Custom ArgsMatcher

### DIFF
--- a/Mockista/ArgsMatcher.php
+++ b/Mockista/ArgsMatcher.php
@@ -20,7 +20,7 @@ class ArgsMatcher
 		}
 	}
 
-	private function hashArg($arg)
+	protected function hashArg($arg)
 	{
 		if (is_object($arg)) {
 			return spl_object_hash($arg);

--- a/Mockista/Mock.php
+++ b/Mockista/Mock.php
@@ -11,9 +11,12 @@ class Mock implements MockInterface
 
 	private $name = NULL;
 
-	public function __construct()
+	public function __construct(ArgsMatcher $argsMatcher = NULL)
 	{
-		$this->argsMatcher = new ArgsMatcher();
+		if ($argsMatcher === NULL) {
+			$argsMatcher = new ArgsMatcher();
+		}
+		$this->argsMatcher = $argsMatcher;
 	}
 
 	public function assertExpectations()

--- a/Mockista/MockBuilder.php
+++ b/Mockista/MockBuilder.php
@@ -11,15 +11,25 @@ class MockBuilder
 	/** @var Mock */
 	private $mock;
 
-	public function __construct($className = NULL, array $defaults = array())
+	/** @var ArgsMatcher */
+	private $argsMatcher;
+
+	public function __construct($className = NULL, array $defaults = array(), ArgsMatcher $argsMatcher = NULL)
 	{
 		if (is_array($className)) {
 			$defaults = $className;
 			$className = NULL;
 		}
 
+		$this->argsMatcher = $argsMatcher;
+
 		$this->mock = $this->createMock($className);
 		$this->addMethods($defaults);
+	}
+
+	public function setArgsMatcher(ArgsMatcher $argsMatcher = NULL)
+	{
+		$this->argsMatcher = $argsMatcher;
 	}
 
 	public static function createFromMock($mock)
@@ -48,10 +58,10 @@ class MockBuilder
 
 			eval($code);
 			$mock = new $newName();
-			$mock->mockista = new Mock();
+			$mock->mockista = new Mock($this->argsMatcher);
 			$mock->mockista->setName($class);
 		} else {
-			$mock = new Mock();
+			$mock = new Mock($this->argsMatcher);
 		}
 
 		return $mock;

--- a/Mockista/Registry.php
+++ b/Mockista/Registry.php
@@ -7,18 +7,32 @@ class Registry
 
 	/** @var MockInterface[] */
 	private $mocks = array();
-
+	
 	private $mockId = 1;
+
+	/** @var ArgsMatcher */
+	private $argsMatcher;
+
+	public function __construct(ArgsMatcher $argsMatcher = NULL)
+	{
+		$this->argsMatcher = $argsMatcher;
+	}
+
+	public function setArgsMatcher(ArgsMatcher $argsMatcher = NULL)
+	{
+		$this->argsMatcher = $argsMatcher;
+	}
 
 	/**
 	 * Create mock
 	 * @param string $class mocked class
 	 * @param array $methods
+	 * @param ArgsMatcher $argsMatcher
 	 * @return MockInterface
 	 */
-	public function create($class = NULL, array $methods = array())
+	public function create($class = NULL, array $methods = array(), ArgsMatcher $argsMatcher = NULL)
 	{
-		return $this->createBuilder($class, $methods)->getMock();
+		return $this->createBuilder($class, $methods, $argsMatcher)->getMock();
 	}
 
 	/**
@@ -39,11 +53,11 @@ class Registry
 	 * @param array $methods
 	 * @return MockBuilder
 	 */
-	public function createBuilder($class = NULL, array $methods = array())
+	public function createBuilder($class = NULL, array $methods = array(), ArgsMatcher $argsMatcher = NULL)
 	{
 		$name = $class ? "{$class}#{$this->mockId}" : "#{$this->mockId}";
 
-		return $this->createNamedBuilder($name, $class, $methods);
+		return $this->createNamedBuilder($name, $class, $methods, $argsMatcher);
 	}
 
 	/**
@@ -54,9 +68,12 @@ class Registry
 	 * @param array $methods
 	 * @return MockBuilder
 	 */
-	public function createNamedBuilder($name, $class = NULL, array $methods = array())
+	public function createNamedBuilder($name, $class = NULL, array $methods = array(), ArgsMatcher $argsMatcher = NULL)
 	{
-		$builder = new MockBuilder($class, $methods);
+		if ($argsMatcher === NULL) {
+			$argsMatcher = $this->argsMatcher;
+		}
+		$builder = new MockBuilder($class, $methods, $argsMatcher);
 		$mock = $builder->getMock();
 		if (isset($this->mocks[$name])) {
 			throw new InvalidArgumentException("Mock with name {$name} is already registered.");


### PR DESCRIPTION
New version of pull request #9 rebased to current master.

---

Default object args matching based on spl_object_hash is not practical in case of value object, which equality is based only on properties values. Custom argsMatchers can replace default argsMatcher to support different matching policy.

Example of CustomArgsMatcher we currently use:

``` PHP
class CustomArgsMatcher extends \Mockista\ArgsMatcher {

  protected function hashArg($arg) {
    if($arg instanceof Entity) {
      // entites are matched based on values of their properties
      return md5(print_r($arg->getProperties()->toArray(), true));
    } elseif($arg instanceof \DateTime) {
      //two DateTime objects are equivalent it they represent same time
      return md5(print_r($arg->format("Y-m-d_H:i:se")), true);
    } elseif($arg instanceof \Nette\ArrayHash) {
      // ArrayHash wrapper of array is matched based on it's content
      return parent::hashArg((array)$arg);
    } else {
      // fallback for all other types
      return parent::hashArg($arg);
    }
  }

}
```

Usage:

``` PHP
$registry = new \Mockista\Registry(new CustomArgsMatcher()); 
// all mocks created by registry will use CustomArgsMatcher
```

``` PHP
$mock = $registry->create();
$mock->setArgsMatcher(new CustomArgsMatcher());
// change argsMatcher only for specific mock
```

``` PHP
$date1 = new \DateTime("2014-05-23 10:00:00");
$date2 = new \DateTime("2014-05-23 10:00:00");
$mock->expects('method')->with($date1)->once();
$mock->method($date2);
$mock->assertExpectations();
// assert is valid if CustomArgsMatcher compare DateTime only by value
```
