### PR TITLE
Fix mock freeze: only expected methods must by frozen

### DIFF
--- a/Mockista/Mock.php
+++ b/Mockista/Mock.php
@@ -20,7 +20,7 @@ class Mock implements MockInterface
 
 	public function assertExpectations()
 	{
-		if ($this->frozen) {
+		if ($this->frozen && isset($this->methods['assertExpectations'])) {
 			return $this->__call(__FUNCTION__, func_get_args());
 		}
 		foreach ($this->methods as $method) {
@@ -36,7 +36,7 @@ class Mock implements MockInterface
 	 */
 	public function getName()
 	{
-		if ($this->frozen) {
+		if ($this->frozen && isset($this->methods['getName'])) {
 			return $this->__call(__FUNCTION__, func_get_args());
 		}
 		return $this->name;
@@ -48,7 +48,7 @@ class Mock implements MockInterface
 	 */
 	public function setName($name)
 	{
-		if ($this->frozen) {
+		if ($this->frozen && isset($this->methods['setName'])) {
 			return $this->__call(__FUNCTION__, func_get_args());
 		}
 		$this->name = $name;
@@ -60,7 +60,7 @@ class Mock implements MockInterface
 	 */
 	public function freeze()
 	{
-		if ($this->frozen) {
+		if ($this->frozen && isset($this->methods['freeze'])) {
 			return $this->__call(__FUNCTION__, func_get_args());
 		}
 		$this->frozen = TRUE;
@@ -114,7 +114,7 @@ class Mock implements MockInterface
 	 */
 	public function expects($name)
 	{
-		if ($this->frozen) {
+		if ($this->frozen && isset($this->methods['expects'])) {
 			return $this->__call(__FUNCTION__, func_get_args());
 		}
 

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -88,14 +88,20 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals("Already freezed", $mock->setName("name"));
 	}
 
-	/**
-	 * @expectedException Mockista\MockException
-	 * @expectedMessage   Unexpected call in mock Test::getName()
-	 */
-	function testFreezeMockExceptionOnUndefinedMethod()
+	function testFreezeMockWithAssertExpectations()
+	{
+		$mock1 = $this->object->create();
+		$mock1->expects('abc')->once();
+		$mock1->abc();
+		$mock1->freeze();
+		$this->object->assertExpectations();
+	}
+
+	function testFreezeMockNotFrozenMethodCall()
 	{
 		$mock = $this->object->create("Mockista\A");
 		$mock->freeze();
+		$mock->setName('Test');
 		$this->assertEquals("Test", $mock->getName());
 	}
 


### PR DESCRIPTION
Mock freeze causes impossibility of calling assertExpectations in test cases. Possible solution is to froze only expected methods.
