### PR TITLE
Use Tracy\Dumper for dumping variables

### DIFF
--- a/Mockista/ArgsMatcher.php
+++ b/Mockista/ArgsMatcher.php
@@ -2,6 +2,8 @@
 
 namespace Mockista;
 
+use Tracy\Dumper;
+
 class ArgsMatcher
 {
 
@@ -28,9 +30,7 @@ class ArgsMatcher
 			try {
 				return md5(serialize($arg));
 			} catch (\Exception $e) {
-				ob_start();
-				var_dump($arg);
-				return md5(ob_get_clean());
+				return Dumper::toText($arg);
 			}
 		}
 	}

--- a/Mockista/Mock.php
+++ b/Mockista/Mock.php
@@ -2,6 +2,8 @@
 
 namespace Mockista;
 
+use Tracy\Dumper;
+
 class Mock implements MockInterface
 {
 
@@ -67,17 +69,7 @@ class Mock implements MockInterface
 		}
 
 		if (!$best) {
-			$argsStr = '';
-
-			foreach ($args as $arg) {
-				ob_start();
-				var_dump($arg);
-				$lines = explode(PHP_EOL, ob_get_clean());
-				for ($i = 0; $i < count($lines); $i++) {
-					$argsStr .= PHP_EOL . ($i === 0 ? '- ' : '  ') . $lines[$i];
-				}
-
-			}
+			$argsStr = Dumper::toText($args);
 			$objectName = $this->name ? $this->name : 'unnammed';
 			throw new MockException("Unexpected call in mock $objectName::$name(), args:\n$argsStr", MockException::CODE_INVALID_ARGS);
 		}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
 		}
 	],
 	"license": "BSD-3-Clause",
+    "require": {
+        "tracy/tracy": ">2.2.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
Just quickfix or args dumping to prevent false passing tests. Not based on current master (we have diverged, I will do merge in future).

It's just example of our dirty solution for problem described at #32