### PR TITLE
generate method typehints with absolute FQCN

### DIFF
--- a/Mockista/ClassGenerator/MethodFinder.php
+++ b/Mockista/ClassGenerator/MethodFinder.php
@@ -59,7 +59,7 @@ class MethodFinder
 			} else {
 				$klass = $parameter->getClass();
 				if ($klass) {
-					$parameterDesc['typehint'] = $klass->getName();
+					$parameterDesc['typehint'] = '\\' . $klass->getName();
 				}
 				else {
 					$parameterDesc['typehint'] = null;


### PR DESCRIPTION
... so that mocking `Foo\Foo` class doesn't fail on "Declaration of ... should be compatible with...":
```php
<?php

namespace Foo;

class Bar {}

class Foo
{
    public function something(Bar $param) {}
}
```