### PR TITLE
Remove undefined argsMatcher

### DIFF
--- a/Mockista/Mock.php
+++ b/Mockista/Mock.php
@@ -112,7 +112,7 @@ class Mock implements MockInterface
 		}
 
 		$this->checkMethodsNamespace($name);
-		$method = new Method($this->argsMatcher);
+		$method = new Method();
 		$method->owningMock = $this;
 		$method->name = $name;
 		$this->methods[$name][] = $method;


### PR DESCRIPTION
This is forgotten reference to ArgsMatcher which was removed in https://github.com/janmarek/mockista/commit/7eeede5dc7243cd314f9e9156d68adbb4dcab70e#diff-c42aba9f06914554940de1810674a02d

EDIT: this has already been solved in https://github.com/janmarek/mockista/pull/35